### PR TITLE
Add web interface for coffee bean classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,18 @@ Good-or-Bad-CoffeeBeans/
 | 📦 資料處理 | 對咖啡豆圖片進行標準化、分類、增強 |
 | 🔬 模型訓練 | 使用 CNN 訓練良品 vs 瑕疵 |
 | 🧪 模型評估 | 分類報告、混淆矩陣、視覺化結果 |
-| ⚙️ 模型應用(尚未完成) | 可應用於實驗、分級流程或即時檢測 |
+| 🌐 網頁推論 | Flask + HTML 前端介面，支援模型選擇、照片上傳與分類結果展示 |
+| ⚙️ 模型應用 | 可應用於實驗、分級流程或即時檢測 |
+
+---
+
+## 🌐 網頁推論介面 | Web Interface
+
+1. 安裝依賴：`pip install flask pillow torch torchvision`（或參考 `requirements.txt` 自行建立環境）。
+2. 將訓練完成的 `.pth` 權重檔放到專案根目錄下的 `models/`，必要時新增對應的 JSON 設定檔（詳見 `models/README.md`）。
+3. 執行 `python app.py` 啟動 Flask 伺服器。
+4. 開啟瀏覽器連線至 <http://localhost:5000>。
+5. 前端頁面提供模型清單、圖片預覽、分類結果與各類別機率，協助快速驗證模型效果。
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import torch
+from flask import Flask, jsonify, render_template, request
+from PIL import Image, ImageOps
+from torch import nn
+from torchvision import transforms
+from torchvision.models import convnext_tiny, resnet18
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+app = Flask(__name__)
+app.config["MAX_CONTENT_LENGTH"] = 10 * 1024 * 1024  # 10 MB 上傳上限
+
+DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+MODEL_DIR = Path(__file__).resolve().parent / "models"
+ALLOWED_EXTENSIONS = {"jpg", "jpeg", "png", "bmp", "webp"}
+
+BEAN_LABELS = {
+    "ethiopia_washed": "衣索比亞水洗豆",
+    "kenya_natural": "肯亞日曬豆",
+    "honduras_natural": "宏都拉斯日曬豆",
+}
+
+ARCHITECTURE_LABELS = {
+    "resnet18": "ResNet-18",
+    "convnext_tiny": "ConvNeXt-Tiny",
+    "custom": "Custom CNN",
+    "ultrafast": "UltraFast CNN",
+}
+
+MODEL_NAME_PATTERN = re.compile(
+    r"^(?P<bean>.+)_(?P<arch>resnet18|convnext_tiny|custom|ultrafast)(?P<suffix>_Noback)?_best_model$"
+)
+
+
+@dataclass
+class ModelInfo:
+    key: str
+    display_name: str
+    bean_type: str
+    architecture: str
+    img_size: int
+    classes: List[str]
+    path: Path
+    description: Optional[str] = None
+    config_path: Optional[Path] = None
+
+    @property
+    def bean_display_name(self) -> str:
+        return BEAN_LABELS.get(self.bean_type, self.bean_type.replace("_", " ").title())
+
+    @property
+    def architecture_label(self) -> str:
+        return ARCHITECTURE_LABELS.get(self.architecture, self.architecture)
+
+    def to_metadata(self) -> Dict[str, object]:
+        return {
+            "key": self.key,
+            "display_name": self.display_name,
+            "bean_type": self.bean_type,
+            "bean_display_name": self.bean_display_name,
+            "architecture": self.architecture,
+            "architecture_label": self.architecture_label,
+            "img_size": self.img_size,
+            "classes": self.classes,
+            "model_file": self.path.name,
+            "has_weights": self.path.exists(),
+            "description": self.description,
+            "config_file": self.config_path.name if self.config_path else None,
+        }
+
+
+MODEL_CACHE: Dict[str, nn.Module] = {}
+TRANSFORM_CACHE: Dict[int, transforms.Compose] = {}
+
+
+def is_allowed_file(filename: str) -> bool:
+    return "." in filename and filename.rsplit(".", 1)[1].lower() in ALLOWED_EXTENSIONS
+
+
+def pad_to_square(image: Image.Image, fill: int = 0) -> Image.Image:
+    width, height = image.size
+    if width == height:
+        return image
+    if width > height:
+        diff = width - height
+        padding = (0, diff // 2, 0, diff - diff // 2)
+    else:
+        diff = height - width
+        padding = (diff // 2, 0, diff - diff // 2, 0)
+    return ImageOps.expand(image, border=padding, fill=fill)
+
+
+def build_transform(img_size: int) -> transforms.Compose:
+    if img_size not in TRANSFORM_CACHE:
+        TRANSFORM_CACHE[img_size] = transforms.Compose(
+            [
+                transforms.Lambda(lambda img: pad_to_square(img, fill=0)),
+                transforms.Resize((img_size, img_size)),
+                transforms.ToTensor(),
+                transforms.Normalize([0.5] * 3, [0.5] * 3),
+            ]
+        )
+    return TRANSFORM_CACHE[img_size]
+
+
+def build_model(architecture: str, num_classes: int, img_size: int) -> nn.Module:
+    architecture = architecture.lower()
+
+    if architecture == "resnet18":
+        model = resnet18(weights=None)
+        model.fc = nn.Linear(model.fc.in_features, num_classes)
+        return model
+
+    if architecture == "convnext_tiny":
+        model = convnext_tiny(weights=None)
+        in_features = model.classifier[2].in_features
+        model.classifier[2] = nn.Linear(in_features, num_classes)
+        return model
+
+    if architecture == "custom":
+        class CustomCNN(nn.Module):
+            def __init__(self, num_classes: int, img_size: int) -> None:
+                super().__init__()
+                self.features = nn.Sequential(
+                    nn.Conv2d(3, 32, 3, padding=1),
+                    nn.BatchNorm2d(32),
+                    nn.ReLU(),
+                    nn.MaxPool2d(2),
+                    nn.Conv2d(32, 64, 3, padding=1),
+                    nn.BatchNorm2d(64),
+                    nn.ReLU(),
+                    nn.MaxPool2d(2),
+                    nn.Conv2d(64, 128, 3, padding=1),
+                    nn.BatchNorm2d(128),
+                    nn.ReLU(),
+                    nn.MaxPool2d(2),
+                )
+                feature_dim = 128 * (img_size // 8) * (img_size // 8)
+                self.classifier = nn.Sequential(
+                    nn.Flatten(),
+                    nn.Linear(feature_dim, 256),
+                    nn.ReLU(),
+                    nn.Dropout(0.5),
+                    nn.Linear(256, num_classes),
+                )
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return self.classifier(self.features(x))
+
+        return CustomCNN(num_classes, img_size)
+
+    if architecture == "ultrafast":
+        class UltraFastCNN(nn.Module):
+            def __init__(self, num_classes: int) -> None:
+                super().__init__()
+                self.features = nn.Sequential(
+                    nn.Conv2d(3, 8, 5, 2, 1),
+                    nn.ReLU(),
+                    nn.Conv2d(8, 16, 5, 2, 1),
+                    nn.ReLU(),
+                    nn.Conv2d(16, 32, 3, 2, 1),
+                    nn.ReLU(),
+                    nn.AdaptiveAvgPool2d((1, 1)),
+                )
+                self.classifier = nn.Sequential(
+                    nn.Flatten(),
+                    nn.Linear(32, num_classes),
+                )
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return self.classifier(self.features(x))
+
+        return UltraFastCNN(num_classes)
+
+    raise ValueError(f"未知的模型架構：{architecture}")
+
+
+def load_config_from_json(config_path: Path) -> Optional[ModelInfo]:
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logging.warning("無法讀取模型設定 %s：%s", config_path.name, exc)
+        return None
+
+    required_fields = {"bean_type", "architecture", "img_size", "classes"}
+    missing = required_fields - data.keys()
+    if missing:
+        logging.warning("設定檔 %s 缺少欄位：%s", config_path.name, ", ".join(sorted(missing)))
+        return None
+
+    classes = data.get("classes")
+    if not isinstance(classes, list) or not classes:
+        logging.warning("設定檔 %s 的 classes 格式不正確", config_path.name)
+        return None
+
+    model_file = data.get("model_file")
+    model_path = (
+        (config_path.parent / model_file).resolve() if model_file else config_path.with_suffix(".pth").resolve()
+    )
+
+    display_name = data.get("display_name")
+    if not display_name:
+        bean_display = BEAN_LABELS.get(data["bean_type"], data["bean_type"].replace("_", " ").title())
+        arch_label = ARCHITECTURE_LABELS.get(data["architecture"], data["architecture"])
+        display_name = f"{bean_display} - {arch_label}"
+
+    key = data.get("key") or config_path.stem
+
+    return ModelInfo(
+        key=key,
+        display_name=display_name,
+        bean_type=data["bean_type"],
+        architecture=data["architecture"],
+        img_size=int(data["img_size"]),
+        classes=[str(cls) for cls in classes],
+        path=model_path,
+        description=data.get("description"),
+        config_path=config_path,
+    )
+
+
+def infer_info_from_filename(model_path: Path) -> Optional[ModelInfo]:
+    match = MODEL_NAME_PATTERN.match(model_path.stem)
+    if not match:
+        logging.info("跳過無法推斷資訊的模型檔案：%s", model_path.name)
+        return None
+
+    bean_type = match.group("bean")
+    architecture = match.group("arch")
+    suffix = match.group("suffix") or ""
+
+    bean_display = BEAN_LABELS.get(bean_type, bean_type.replace("_", " ").title())
+    arch_label = ARCHITECTURE_LABELS.get(architecture, architecture)
+    display_name = f"{bean_display} - {arch_label}"
+    if suffix:
+        display_name += " (Noback)"
+
+    classes = ["bad", "good"]
+    description = "自動從檔名推斷設定，分類標籤預設為 bad / good。"
+
+    return ModelInfo(
+        key=model_path.stem,
+        display_name=display_name,
+        bean_type=bean_type,
+        architecture=architecture,
+        img_size=128,
+        classes=classes,
+        path=model_path.resolve(),
+        description=description,
+        config_path=None,
+    )
+
+
+def load_model_infos() -> List[ModelInfo]:
+    MODEL_DIR.mkdir(parents=True, exist_ok=True)
+    infos: List[ModelInfo] = []
+
+    for config_path in sorted(MODEL_DIR.glob("*.json")):
+        info = load_config_from_json(config_path)
+        if info:
+            infos.append(info)
+
+    known_paths = {info.path for info in infos}
+
+    for model_path in sorted(MODEL_DIR.glob("*.pth")):
+        resolved = model_path.resolve()
+        if resolved in known_paths:
+            continue
+        info = infer_info_from_filename(resolved)
+        if info:
+            infos.append(info)
+
+    unique_infos: Dict[str, ModelInfo] = {}
+    for info in infos:
+        if info.key in unique_infos:
+            logging.warning("模型 key 重複：%s，僅保留第一個設定。", info.key)
+            continue
+        unique_infos[info.key] = info
+
+    return sorted(unique_infos.values(), key=lambda item: item.display_name.lower())
+
+
+MODEL_INFOS = load_model_infos()
+MODEL_LOOKUP = {info.key: info for info in MODEL_INFOS}
+
+
+def get_or_load_model(model_key: str) -> nn.Module:
+    if model_key not in MODEL_LOOKUP:
+        raise KeyError(f"未知的模型 key：{model_key}")
+
+    if model_key not in MODEL_CACHE:
+        info = MODEL_LOOKUP[model_key]
+        logging.info("載入模型：%s", info.display_name)
+        model = build_model(info.architecture, len(info.classes), info.img_size)
+        try:
+            state_dict = torch.load(info.path, map_location=DEVICE)
+        except FileNotFoundError as exc:
+            logging.error("找不到模型檔案：%s", info.path)
+            raise exc
+
+        if isinstance(state_dict, dict) and "state_dict" in state_dict:
+            state_dict = state_dict["state_dict"]
+        model.load_state_dict(state_dict)
+        model.to(DEVICE)
+        model.eval()
+        MODEL_CACHE[model_key] = model
+
+    return MODEL_CACHE[model_key]
+
+
+def predict_image(model_key: str, image: Image.Image) -> Dict[str, object]:
+    info = MODEL_LOOKUP[model_key]
+    model = get_or_load_model(model_key)
+    transform = build_transform(info.img_size)
+    tensor = transform(image.convert("RGB")).unsqueeze(0).to(DEVICE)
+
+    with torch.no_grad():
+        logits = model(tensor)
+        probabilities = torch.softmax(logits, dim=1)[0].detach().cpu().tolist()
+
+    results = [
+        {"label": label, "probability": float(prob)}
+        for label, prob in zip(info.classes, probabilities)
+    ]
+    prediction = max(results, key=lambda item: item["probability"])
+
+    return {
+        "prediction": prediction,
+        "probabilities": results,
+        "model": info.to_metadata(),
+    }
+
+
+@app.route("/")
+def index():
+    return render_template("index.html", models=MODEL_INFOS)
+
+
+@app.post("/api/predict")
+def api_predict():
+    if not MODEL_LOOKUP:
+        return jsonify({"error": "尚未在 models 資料夾中找到可用的模型。"}), 400
+
+    model_key = request.form.get("model_key")
+    if not model_key:
+        return jsonify({"error": "請選擇要使用的模型。"}), 400
+
+    if model_key not in MODEL_LOOKUP:
+        return jsonify({"error": f"未知的模型：{model_key}"}), 400
+
+    file_storage = request.files.get("image")
+    if file_storage is None or file_storage.filename == "":
+        return jsonify({"error": "請選擇要上傳的咖啡豆照片。"}), 400
+
+    if not is_allowed_file(file_storage.filename):
+        return jsonify({"error": "檔案格式僅支援 JPG、JPEG、PNG、BMP、WEBP。"}), 400
+
+    try:
+        image = Image.open(file_storage.stream)
+    except Exception:
+        return jsonify({"error": "無法讀取圖片，請確認檔案是否為有效的影像格式。"}), 400
+
+    try:
+        result = predict_image(model_key, image)
+    except FileNotFoundError:
+        info = MODEL_LOOKUP[model_key]
+        return jsonify({"error": f"找不到模型權重檔案：{info.path.name}"}), 500
+    except RuntimeError as exc:
+        logging.exception("模型推論失敗：%s", exc)
+        return jsonify({"error": f"模型推論失敗：{exc}"}), 500
+
+    return jsonify(result)
+
+
+@app.get("/api/models")
+def api_models():
+    return jsonify({"models": [info.to_metadata() for info in MODEL_INFOS]})
+
+
+if __name__ == "__main__":
+    host = "0.0.0.0"
+    port = int(os.environ.get("PORT", 5000))
+    logging.info("啟動網頁服務：http://%s:%s", host, port)
+    app.run(host=host, port=port, debug=False)

--- a/models/README.md
+++ b/models/README.md
@@ -1,0 +1,52 @@
+# 模型與設定檔說明
+
+將推論所需的模型權重（`.pth`）與對應設定檔（`.json`，可選）放置於此資料夾。
+
+## 1. 權重檔命名規則
+
+若沒有額外的設定檔，系統會嘗試從檔名推斷資訊。建議遵循訓練腳本的預設格式：
+
+```
+{豆種}_{模型架構}[_Noback]_best_model.pth
+```
+
+例如：
+
+- `ethiopia_washed_custom_best_model.pth`
+- `honduras_natural_resnet18_Noback_best_model.pth`
+
+沒有 JSON 設定時，系統會假設影像尺寸為 128、類別為 `bad / good`。
+
+## 2. JSON 設定檔（建議）
+
+建立與權重同名的 JSON（或自訂 `model_file` 欄位）可以明確指定模型資訊：
+
+```json
+{
+  "key": "ethiopia_washed_custom_best_model",
+  "display_name": "衣索比亞水洗豆 - Custom CNN (去背)",
+  "bean_type": "ethiopia_washed",
+  "architecture": "custom",
+  "img_size": 128,
+  "classes": ["bad", "good"],
+  "model_file": "ethiopia_washed_custom_best_model.pth",
+  "description": "使用去背資料訓練的 Custom CNN 模型"
+}
+```
+
+欄位說明：
+
+- `key`：模型唯一識別碼（未填時預設為檔名）。
+- `display_name`：前端顯示名稱。
+- `bean_type`：豆種資料夾名稱，例如 `ethiopia_washed`。
+- `architecture`：支援 `resnet18`、`convnext_tiny`、`custom`、`ultrafast`。
+- `img_size`：訓練時的輸入尺寸。
+- `classes`：分類標籤，順序需與訓練時一致。
+- `model_file`（選填）：權重檔檔名，預設為同名 `.pth`。
+- `description`（選填）：顯示在前端的補充說明。
+
+## 3. 常見問題
+
+- 權重檔不存在：前端會顯示警告，推論時會回傳錯誤訊息。
+- 類別數不符合：請確認 JSON `classes` 與模型輸出維度一致。
+- 需要更新模型列表：新增檔案後重新整理網頁即可載入。

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask>=3.0.0,<4.0.0
+pillow>=10.0.0
+torch>=2.0.0
+torchvision>=0.15.0

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,241 @@
+:root {
+  color-scheme: light;
+  font-family: "Noto Sans TC", "Microsoft JhengHei", "PingFang TC", sans-serif;
+  --bg: #f6f7fb;
+  --card-bg: #ffffff;
+  --primary: #6f4e37;
+  --primary-dark: #563a29;
+  --text: #2f2f30;
+  --muted: #6f6f76;
+  --border: #e1e4ec;
+  --danger: #b42318;
+  --success: #2b8a3e;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 3rem;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.page-header h1 {
+  margin-bottom: 0.5rem;
+  font-size: 2.25rem;
+}
+
+.page-header .lead {
+  margin: 0;
+  color: var(--muted);
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: 16px;
+  padding: 1.75rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
+}
+
+.card h2 {
+  margin-top: 0;
+  margin-bottom: 1.25rem;
+  font-size: 1.5rem;
+  color: var(--primary-dark);
+}
+
+.field {
+  margin-bottom: 1.5rem;
+}
+
+label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+select,
+input[type="file"] {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  font-size: 1rem;
+  background: #fff;
+}
+
+select:focus,
+input[type="file"]:focus {
+  outline: 2px solid rgba(111, 78, 55, 0.35);
+}
+
+.hint {
+  margin-top: 0.35rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.preview {
+  border: 1px dashed var(--border);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background: #fafafa;
+}
+
+.preview img {
+  max-width: 100%;
+  display: block;
+  margin-top: 0.5rem;
+  border-radius: 12px;
+}
+
+.actions {
+  text-align: right;
+}
+
+button[type="submit"] {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1.6rem;
+  border-radius: 999px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+button[type="submit"]:hover:not(:disabled) {
+  background: var(--primary-dark);
+  transform: translateY(-1px);
+}
+
+button[type="submit"]:disabled {
+  background: #b79a88;
+  cursor: not-allowed;
+}
+
+.message {
+  margin-top: 1rem;
+  padding: 0.85rem 1rem;
+  border-radius: 10px;
+  background: rgba(180, 35, 24, 0.12);
+  color: var(--danger);
+}
+
+.hidden {
+  display: none;
+}
+
+.result-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem 1.25rem;
+  margin: 0 0 1rem;
+}
+
+.result-meta dt {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.result-meta dd {
+  margin: 0.35rem 0 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.probability-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.probability-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: #fdfdfd;
+}
+
+.probability-list .prob-label {
+  font-weight: 600;
+}
+
+.probability-list .prob-value {
+  font-variant-numeric: tabular-nums;
+}
+
+.model-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.model-item {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.2rem;
+  background: #fbfbfd;
+}
+
+.model-item h3 {
+  margin-top: 0;
+  margin-bottom: 0.6rem;
+  color: var(--primary-dark);
+}
+
+.model-item p {
+  margin: 0.3rem 0;
+  line-height: 1.5;
+}
+
+.model-item .description {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.model-item .warning {
+  color: var(--danger);
+  font-weight: 600;
+}
+
+.empty-state {
+  text-align: center;
+}
+
+.empty-state p {
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+@media (max-width: 640px) {
+  .card {
+    padding: 1.25rem;
+  }
+
+  button[type="submit"] {
+    width: 100%;
+  }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>咖啡豆良品分類器 - Web 介面</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}" />
+  </head>
+  <body>
+    <main class="container">
+      <header class="page-header">
+        <h1>☕ Cofe_log 咖啡豆分類</h1>
+        <p class="lead">
+          上傳咖啡豆照片，選擇訓練好的模型，即時取得良品 / 瑕疵分類結果。
+        </p>
+      </header>
+
+      {% if models %}
+      <section class="card" id="upload-card">
+        <h2>上傳照片並選擇模型</h2>
+        <form id="upload-form" method="post" enctype="multipart/form-data" novalidate>
+          <div class="field">
+            <label for="model-select">選擇豆種與模型</label>
+            <select id="model-select" name="model_key" required>
+              <option value="" disabled selected>請選擇模型</option>
+              {% for model in models %}
+              <option
+                value="{{ model.key }}"
+                data-bean="{{ model.bean_display_name }}"
+                data-classes="{{ model.classes | join('、') }}"
+                data-arch="{{ model.architecture_label }}"
+              >
+                {{ model.display_name }}{% if not model.path.exists() %}（⚠️ 未找到權重檔）{% endif %}
+              </option>
+              {% endfor %}
+            </select>
+            <p class="hint">
+              模型列表依據 <code>models</code> 資料夾內的設定與權重自動產生。
+            </p>
+          </div>
+
+          <div class="field">
+            <label for="image-input">上傳咖啡豆照片</label>
+            <input id="image-input" type="file" name="image" accept="image/*" required />
+            <p class="hint">支援 JPG、PNG、BMP、WEBP，檔案大小上限 10 MB。</p>
+          </div>
+
+          <div class="preview" id="preview-wrapper" hidden>
+            <p>預覽：</p>
+            <img id="preview-image" alt="咖啡豆照片預覽" />
+          </div>
+
+          <div class="actions">
+            <button type="submit" id="submit-button">開始分類</button>
+          </div>
+        </form>
+        <div class="message" id="error-box" hidden></div>
+      </section>
+
+      <section class="card hidden" id="result-card">
+        <h2>分類結果</h2>
+        <dl class="result-meta">
+          <div>
+            <dt>使用模型</dt>
+            <dd id="result-model"></dd>
+          </div>
+          <div>
+            <dt>豆種</dt>
+            <dd id="result-bean"></dd>
+          </div>
+          <div>
+            <dt>主要預測</dt>
+            <dd id="result-label"></dd>
+          </div>
+        </dl>
+        <div id="result-description"></div>
+        <h3>類別機率</h3>
+        <ul id="probability-list" class="probability-list"></ul>
+      </section>
+
+      <section class="card" id="models-card">
+        <h2>可用模型總覽</h2>
+        <ul class="model-list">
+          {% for model in models %}
+          <li class="model-item">
+            <h3>{{ model.display_name }}</h3>
+            <p><strong>豆種：</strong>{{ model.bean_display_name }}（{{ model.bean_type }}）</p>
+            <p><strong>架構：</strong>{{ model.architecture_label }}</p>
+            <p><strong>分類標籤：</strong>{{ model.classes | join('、') }}</p>
+            <p><strong>權重檔：</strong>{{ model.path.name }}</p>
+            {% if model.description %}
+            <p class="description">{{ model.description }}</p>
+            {% endif %}
+            {% if not model.path.exists() %}
+            <p class="warning">⚠️ 未找到對應的權重檔案，請確認 <code>{{ model.path.name }}</code> 已放入 models 資料夾。</p>
+            {% endif %}
+          </li>
+          {% endfor %}
+        </ul>
+      </section>
+      {% else %}
+      <section class="card empty-state">
+        <h2>尚未找到可用的模型</h2>
+        <p>
+          請先將訓練好的 <code>.pth</code> 權重檔放入 <code>models/</code> 資料夾，並視需要新增對應的
+          JSON 設定檔，重新整理頁面後即可在此選擇模型進行推論。
+        </p>
+      </section>
+      {% endif %}
+    </main>
+
+    <script>
+      const form = document.getElementById("upload-form");
+      const previewWrapper = document.getElementById("preview-wrapper");
+      const previewImage = document.getElementById("preview-image");
+      const imageInput = document.getElementById("image-input");
+      const submitButton = document.getElementById("submit-button");
+      const errorBox = document.getElementById("error-box");
+      const resultCard = document.getElementById("result-card");
+      const resultModel = document.getElementById("result-model");
+      const resultBean = document.getElementById("result-bean");
+      const resultLabel = document.getElementById("result-label");
+      const resultDescription = document.getElementById("result-description");
+      const probabilityList = document.getElementById("probability-list");
+      const modelSelect = document.getElementById("model-select");
+
+      function resetMessage() {
+        errorBox.textContent = "";
+        errorBox.hidden = true;
+      }
+
+      function showError(message) {
+        errorBox.textContent = message;
+        errorBox.hidden = false;
+        resultCard.classList.add("hidden");
+      }
+
+      function updatePreview(file) {
+        if (!file) {
+          previewWrapper.hidden = true;
+          previewImage.removeAttribute("src");
+          return;
+        }
+        const url = URL.createObjectURL(file);
+        previewImage.onload = () => URL.revokeObjectURL(url);
+        previewImage.src = url;
+        previewWrapper.hidden = false;
+      }
+
+      imageInput?.addEventListener("change", () => {
+        const [file] = imageInput.files;
+        updatePreview(file);
+      });
+
+      form?.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        resetMessage();
+
+        if (!modelSelect.value) {
+          showError("請先選擇模型。");
+          return;
+        }
+
+        const file = imageInput.files?.[0];
+        if (!file) {
+          showError("請先選擇要上傳的圖片。");
+          return;
+        }
+
+        const formData = new FormData(form);
+        submitButton.disabled = true;
+        submitButton.textContent = "分類中...";
+
+        try {
+          const response = await fetch("/api/predict", {
+            method: "POST",
+            body: formData,
+          });
+          const payload = await response.json();
+
+          if (!response.ok) {
+            showError(payload.error || "推論失敗，請稍後再試。");
+            return;
+          }
+
+          resultModel.textContent = payload.model.display_name;
+          resultBean.textContent = `${payload.model.bean_display_name}（${payload.model.bean_type}）`;
+          resultLabel.textContent = payload.prediction.label;
+          resultDescription.textContent = payload.model.description || "";
+
+          probabilityList.innerHTML = "";
+          payload.probabilities
+            .sort((a, b) => b.probability - a.probability)
+            .forEach((item) => {
+              const li = document.createElement("li");
+              li.innerHTML = `<span class="prob-label">${item.label}</span><span class="prob-value">${(item.probability * 100).toFixed(2)}%</span>`;
+              probabilityList.appendChild(li);
+            });
+
+          resultCard.classList.remove("hidden");
+        } catch (error) {
+          console.error(error);
+          showError("網路或伺服器發生錯誤，請稍後再試。");
+        } finally {
+          submitButton.disabled = false;
+          submitButton.textContent = "開始分類";
+        }
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a Flask-based inference server that discovers available weight files, exposes REST endpoints, and runs predictions
- create an HTML upload interface with styling for model selection, preview, and probability display
- document the web workflow, dependency requirements, and model configuration guidelines

## Testing
- python -m compileall app.py manual_classifier.py

------
https://chatgpt.com/codex/tasks/task_e_68cba564e78c8328bb86152ec16b31c2